### PR TITLE
使用していない設定ファイルを削除

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,9 +1,0 @@
-// Copyright (c) 2025 izzet-mtg
-// SPDX-License-Identifier: MIT
-
-/** @type {import('next-sitemap').IConfig} */
-module.exports = {
-  siteUrl: 'https://izzet-mtg.github.io/random-commander-jp/',
-  generateRobotsTxt: true,
-  outDir: 'out',
-}


### PR DESCRIPTION
かつてサイトマップ提供プラグインを利用していたが、現在は利用せずに Next.js の自前の機能で手前味噌に設定しているので削除